### PR TITLE
Ft/bot score calculation

### DIFF
--- a/aoe-gwent/src/entities/card/PlayingRowContainer.ts
+++ b/aoe-gwent/src/entities/card/PlayingRowContainer.ts
@@ -1,11 +1,11 @@
+import { gsap } from "gsap";
+import { BloomFilter } from "pixi-filters";
 import { Container, Graphics, Sprite, Text, TextStyle } from "pixi.js";
+import { CardEffect, CardType } from "../../local-server/CardDatabase";
 import { PixiGraphics, PixiSprite } from "../../plugins/engine";
+import { BorderDialog } from "../../ui/components/BorderDialog";
 import { CardContainer, CardContainerLayoutType } from "./CardContainer";
 import { WeatherEffect } from "./WeatherEffect";
-import { gsap } from "gsap";
-import { CardEffect, CardType } from "../../local-server/CardDatabase";
-import { BorderDialog } from "../../ui/components/BorderDialog";
-import { BloomFilter } from "pixi-filters";
 
 export interface PlayingRowConfig {
 	label: string;
@@ -19,6 +19,9 @@ export interface PlayingRowConfig {
  * Specialized container for playing rows (Melee, Ranged, Siege).
  */
 export class PlayingRowContainer extends CardContainer {
+	public weatherEffectApplied = false;
+	public strengthBoost = 0;
+
 	private rowBackground: Container;
 	private highlightOverlay: Graphics;
 	private weatherEffect: WeatherEffect;
@@ -29,9 +32,6 @@ export class PlayingRowContainer extends CardContainer {
 	private bloomFilter: BloomFilter;
 
 	private _score = 0;
-	private _weatherEffectApplied = false;
-
-	private _strengthBoost = 0;
 
 	constructor(config: PlayingRowConfig) {
 		super(
@@ -95,14 +95,6 @@ export class PlayingRowContainer extends CardContainer {
 		});
 	}
 
-	public get weatherEffectApplied(): boolean {
-		return this._weatherEffectApplied;
-	}
-
-	public get strengthBoost(): number {
-		return this._strengthBoost;
-	}
-
 	/**
 	 * Show the highlight overlay
 	 */
@@ -155,7 +147,7 @@ export class PlayingRowContainer extends CardContainer {
 	 * Apply weather effect overlay to the row
 	 */
 	public async applyWeatherEffect(): Promise<void> {
-		this._weatherEffectApplied = true;
+		this.weatherEffectApplied = true;
 		await this.weatherEffect.show();
 	}
 
@@ -164,15 +156,15 @@ export class PlayingRowContainer extends CardContainer {
 	 */
 	public async clearWeatherEffect(): Promise<void> {
 		await this.weatherEffect.hide();
-		this._weatherEffectApplied = false;
+		this.weatherEffectApplied = false;
 	}
 
 	public async applyStrengthBoost(boostAmount: 1 | 2 | 3): Promise<void> {
-		if (this._strengthBoost >= boostAmount) {
+		if (this.strengthBoost >= boostAmount) {
 			return;
 		}
 
-		this._strengthBoost = boostAmount;
+		this.strengthBoost = boostAmount;
 
 		const extraAlpha = 0.2 * boostAmount;
 
@@ -196,7 +188,7 @@ export class PlayingRowContainer extends CardContainer {
 	}
 
 	public async clearStrengthBoost(): Promise<void> {
-		this._strengthBoost = 0;
+		this.strengthBoost = 0;
 
 		this.typeIcon.tint = 0xffffff;
 		this.typeIcon.alpha = 0.3;

--- a/aoe-gwent/src/local-server/BotPlayer.ts
+++ b/aoe-gwent/src/local-server/BotPlayer.ts
@@ -1,6 +1,12 @@
-import { ActionType, PlayerAction } from "./GameTypes";
+import {
+	Card,
+	CardContainer,
+	CardType,
+	PlayingRowContainer,
+} from "../entities/card";
 import { Player, PlayerData } from "../entities/player/Player";
-import { CardContainer, CardType } from "../entities/card";
+import { ScoreCalculator } from "../shared/game/ScoreCalculator";
+import { ActionType, PlayerAction } from "./GameTypes";
 
 /**
  * AI opponent for local games
@@ -10,11 +16,13 @@ export class BotPlayer extends Player {
 
 	private readonly _containerMap: Map<string, CardContainer> = new Map();
 	private readonly _otherPlayer: Player;
+	private readonly _scoreCalculator: ScoreCalculator;
 
 	constructor(playerData: PlayerData, otherPlayer: Player) {
 		super(playerData);
 
 		this._otherPlayer = otherPlayer;
+		this._scoreCalculator = new ScoreCalculator();
 
 		this._containerMap.set(CardType.MELEE, this.melee);
 		this._containerMap.set(CardType.RANGED, this.ranged);
@@ -30,11 +38,26 @@ export class BotPlayer extends Player {
 		await this.delay(this.thinkingDelay);
 
 		const cards = this.hand.cards;
-		const passChance = 0.2;
+
+		if (!cards || cards.length === 0) {
+			return {
+				type: ActionType.PASS_TURN,
+				player: this,
+			};
+		}
+
+		const passChance = 0.01;
+
+		const randomCard = cards[Math.floor(Math.random() * cards.length)];
+		const targetContainer = this._containerMap.get(randomCard.cardData.type);
+
+		this.calculateFutureScore(randomCard);
+
+		await this.delay(1000);
 
 		let pass = false;
 
-		if (this.score > this._otherPlayer.score) {
+		if (this.score > this._otherPlayer.score && this.score > 10) {
 			pass = true;
 		} else if (Math.random() < passChance) {
 			pass = true;
@@ -49,9 +72,6 @@ export class BotPlayer extends Player {
 			};
 		}
 
-		const randomCard = cards[Math.floor(Math.random() * cards.length)];
-		const targetContainer = this._containerMap.get(randomCard.cardData.type);
-
 		return {
 			type: ActionType.PLACE_CARD,
 			player: this,
@@ -65,5 +85,69 @@ export class BotPlayer extends Player {
 	 */
 	private delay(ms: number): Promise<void> {
 		return new Promise((resolve) => setTimeout(resolve, ms));
+	}
+
+	// Check what the score would be if a card is played.
+	private calculateFutureScore(card: Card) {
+		const fakeRow = new PlayingRowContainer({
+			containerType: card.cardData.type,
+			height: 1,
+			label: "Fake Row",
+			labelColor: 0xffffff,
+			width: 1,
+		});
+
+		// See which row to replace:
+
+		const targetRow = this._containerMap.get(card.cardData.type);
+
+		switch (targetRow) {
+			case this.melee:
+				fakeRow.cards = [...this.melee.cards, card];
+				break;
+			case this.ranged:
+				fakeRow.cards = [...this.ranged.cards, card];
+				break;
+			case this.siege:
+				fakeRow.cards = [...this.siege.cards, card];
+				break;
+		}
+
+		const context = {
+			player: {
+				melee: targetRow === this.melee ? fakeRow : this.melee,
+				ranged: targetRow === this.ranged ? fakeRow : this.ranged,
+				siege: targetRow === this.siege ? fakeRow : this.siege,
+				weather: this.weather,
+				hand: this.hand,
+				deck: this.deck,
+				deckPosition: this.deckPosition,
+			},
+			enemy: {
+				melee: this._otherPlayer.melee,
+				ranged: this._otherPlayer.ranged,
+				siege: this._otherPlayer.siege,
+				weather: this._otherPlayer.weather,
+				hand: this._otherPlayer.hand,
+				deck: this._otherPlayer.deck,
+				deckPosition: this._otherPlayer.deckPosition,
+			},
+		};
+
+		const { player, enemy } = this._scoreCalculator.calculateScore(context);
+
+		const totalBotScore = Array.from(player.values()).reduce(
+			(sum, score) => sum + score,
+			0
+		);
+
+		const totalEnemyScore = Array.from(enemy.values()).reduce(
+			(sum, score) => sum + score,
+			0
+		);
+
+		console.log(
+			`If bot plays ${card.cardData.name}, future score would be: ${totalBotScore} vs ${totalEnemyScore}`
+		);
 	}
 }

--- a/aoe-gwent/src/local-server/BotPlayer.ts
+++ b/aoe-gwent/src/local-server/BotPlayer.ts
@@ -54,7 +54,7 @@ export class BotPlayer extends Player {
 			};
 		}
 
-		const passChance = 0.01;
+		const passChance = 0.1;
 
 		const optimalCard = this.findOptimalCard();
 		const targetContainer = this._containerMap.get(optimalCard.cardData.type);
@@ -63,11 +63,11 @@ export class BotPlayer extends Player {
 
 		let pass = false;
 
-		if (this.score > this._otherPlayer.score * 2 && this.score > 10) {
+		if (this._otherPlayer.hasPassed && this.score > this._otherPlayer.score) {
+			pass = true;
+		} else if (this.score > this._otherPlayer.score * 1.5 && this.score > 10) {
 			pass = true;
 		} else if (Math.random() < passChance) {
-			pass = true;
-		} else if (cards.length === 0) {
 			pass = true;
 		}
 

--- a/aoe-gwent/src/local-server/BotPlayer.ts
+++ b/aoe-gwent/src/local-server/BotPlayer.ts
@@ -4,6 +4,7 @@ import {
 	CardType,
 	PlayingRowContainer,
 } from "../entities/card";
+import { WeatherRowContainer } from "../entities/card/WeatherRowContainer";
 import { Player, PlayerData } from "../entities/player/Player";
 import { ScoreCalculator } from "../shared/game/ScoreCalculator";
 import { ActionType, PlayerAction } from "./GameTypes";
@@ -12,6 +13,13 @@ import { ActionType, PlayerAction } from "./GameTypes";
  * AI opponent for local games
  */
 export class BotPlayer extends Player {
+	/**
+	 * 0	Any card is good enough, picks randomly
+	 * 0.5	Only cards in the top half of gain range qualify
+	 * 1	Only the single best card qualifies
+	 */
+	public aggressiveness = 0.5;
+
 	private readonly thinkingDelay = 200;
 
 	private readonly _containerMap: Map<string, CardContainer> = new Map();
@@ -48,16 +56,14 @@ export class BotPlayer extends Player {
 
 		const passChance = 0.01;
 
-		const randomCard = cards[Math.floor(Math.random() * cards.length)];
-		const targetContainer = this._containerMap.get(randomCard.cardData.type);
-
-		this.calculateFutureScore(randomCard);
+		const optimalCard = this.findOptimalCard();
+		const targetContainer = this._containerMap.get(optimalCard.cardData.type);
 
 		await this.delay(1000);
 
 		let pass = false;
 
-		if (this.score > this._otherPlayer.score && this.score > 10) {
+		if (this.score > this._otherPlayer.score * 2 && this.score > 10) {
 			pass = true;
 		} else if (Math.random() < passChance) {
 			pass = true;
@@ -75,7 +81,7 @@ export class BotPlayer extends Player {
 		return {
 			type: ActionType.PLACE_CARD,
 			player: this,
-			card: randomCard,
+			card: optimalCard,
 			targetRow: targetContainer,
 		};
 	}
@@ -87,37 +93,56 @@ export class BotPlayer extends Player {
 		return new Promise((resolve) => setTimeout(resolve, ms));
 	}
 
-	// Check what the score would be if a card is played.
-	private calculateFutureScore(card: Card) {
-		const fakeRow = new PlayingRowContainer({
-			containerType: card.cardData.type,
-			height: 1,
-			label: "Fake Row",
-			labelColor: 0xffffff,
-			width: 1,
+	private findOptimalCard(): Card {
+		const cards = this.hand.cards;
+
+		// Score each card by the gain it would produce
+		const scored = cards.map((card) => {
+			const { bot, enemy } = this.calculateFutureScore(card);
+			const gain = bot - enemy;
+			return { card, gain };
 		});
 
-		// See which row to replace:
+		scored.sort((a, b) => b.gain - a.gain);
 
+		const best = scored[0];
+		const worst = scored[scored.length - 1];
+		const gainRange = best.gain - worst.gain;
+		const threshold = worst.gain + gainRange * this.aggressiveness;
+
+		const goodEnough = scored.filter((s) => s.gain >= threshold);
+
+		// Pick randomly among good-enough cards to avoid being predictable
+		const pick = goodEnough[Math.floor(Math.random() * goodEnough.length)];
+
+		return pick.card;
+	}
+
+	// Check what the score would be if a card is played.
+	private calculateFutureScore(card: Card): {
+		bot: number;
+		enemy: number;
+	} {
 		const targetRow = this._containerMap.get(card.cardData.type);
+		const cloneRow = this.getCloneRow(targetRow!, card);
 
-		switch (targetRow) {
-			case this.melee:
-				fakeRow.cards = [...this.melee.cards, card];
-				break;
-			case this.ranged:
-				fakeRow.cards = [...this.ranged.cards, card];
-				break;
-			case this.siege:
-				fakeRow.cards = [...this.siege.cards, card];
-				break;
-		}
+		const targetMelee = (
+			targetRow === this.melee ? cloneRow : this.melee
+		) as PlayingRowContainer;
+
+		const targetRanged = (
+			targetRow === this.ranged ? cloneRow : this.ranged
+		) as PlayingRowContainer;
+
+		const targetSiege = (
+			targetRow === this.siege ? cloneRow : this.siege
+		) as PlayingRowContainer;
 
 		const context = {
 			player: {
-				melee: targetRow === this.melee ? fakeRow : this.melee,
-				ranged: targetRow === this.ranged ? fakeRow : this.ranged,
-				siege: targetRow === this.siege ? fakeRow : this.siege,
+				melee: targetMelee,
+				ranged: targetRanged,
+				siege: targetSiege,
 				weather: this.weather,
 				hand: this.hand,
 				deck: this.deck,
@@ -146,8 +171,38 @@ export class BotPlayer extends Player {
 			0
 		);
 
-		console.log(
-			`If bot plays ${card.cardData.name}, future score would be: ${totalBotScore} vs ${totalEnemyScore}`
-		);
+		return {
+			bot: totalBotScore,
+			enemy: totalEnemyScore,
+		};
+	}
+
+	private getCloneRow(row: CardContainer, card: Card): CardContainer {
+		let cloneRow;
+
+		if (row instanceof PlayingRowContainer) {
+			cloneRow = new PlayingRowContainer({
+				containerType: row.containerType!,
+				height: 1,
+				label: "_",
+				labelColor: 0xffffff,
+				width: 1,
+			});
+			cloneRow.cards = [...row.cards, card];
+			cloneRow.weatherEffectApplied = row.weatherEffectApplied;
+			cloneRow.strengthBoost = row.strengthBoost;
+		} else if (row instanceof WeatherRowContainer) {
+			cloneRow = new WeatherRowContainer({
+				height: 1,
+				label: "_",
+				width: 1,
+				containerType: CardType.WEATHER,
+			});
+			cloneRow.cards = [...row.cards, card];
+		} else {
+			throw new Error("Unknown row type for cloning");
+		}
+
+		return cloneRow;
 	}
 }

--- a/aoe-gwent/src/local-server/CardEffects.ts
+++ b/aoe-gwent/src/local-server/CardEffects.ts
@@ -50,8 +50,8 @@ export type SelfEffectFunction = (
  * Effect that modifies other cards (aura/passive effect)
  */
 export type AuraEffectFunction = (context: BattlefieldContext) => {
-	affectedRow: PlayingRowContainer;
-	effectValue: number;
+	row: PlayingRowContainer;
+	value: number;
 };
 
 /**
@@ -141,8 +141,8 @@ export const AuraEffects = {
 		description: "Decreases strength of all enemy melee units by 1.",
 		fn: (context: BattlefieldContext) => {
 			return {
-				affectedRow: context.enemy.melee,
-				effectValue: -1,
+				row: context.enemy.melee,
+				value: -1,
 			};
 		},
 	} as EffectMetadata<AuraEffectFunction>,

--- a/aoe-gwent/src/local-server/CardEffects.ts
+++ b/aoe-gwent/src/local-server/CardEffects.ts
@@ -206,9 +206,6 @@ export const TriggerEffects = {
 		},
 	},
 
-	/**
-	 * Freeze: Decreases strength of all melee units to 1
-	 */
 	freezeEffect: {
 		id: "freeze_effect",
 		description: "Reduces strength of all melee units to 1.",
@@ -220,9 +217,6 @@ export const TriggerEffects = {
 		},
 	},
 
-	/**
-	 * Fog: Decreases strength of all ranged units to 1
-	 */
 	fogEffect: {
 		id: "fog_effect",
 		description: "Reduces strength of all ranged units to 1.",
@@ -234,9 +228,6 @@ export const TriggerEffects = {
 		},
 	},
 
-	/**
-	 * Rain: Decreases strength of all siege units to 1
-	 */
 	rainEffect: {
 		id: "rain_effect",
 		description: "Reduces strength of all siege units to 1.",
@@ -287,6 +278,7 @@ export const TriggerEffects = {
 			context.player.ranged.applyStrengthBoost(2);
 		},
 	},
+
 	bracerEffect: {
 		id: "bracer_effect",
 		description: "Increases strength of ranged units by 3.",

--- a/aoe-gwent/src/local-server/CardEffects.ts
+++ b/aoe-gwent/src/local-server/CardEffects.ts
@@ -1,9 +1,31 @@
-import { Card, PlayingRowContainer } from "../entities/card";
-import { Player } from "../entities/player/Player";
+import {
+	Card,
+	CardData,
+	HandContainer,
+	PlayingRowContainer,
+} from "../entities/card";
+import { WeatherRowContainer } from "../entities/card/WeatherRowContainer";
 
 export interface BattlefieldContext {
-	player: Player;
-	enemy: Player;
+	player: {
+		melee: PlayingRowContainer;
+		ranged: PlayingRowContainer;
+		siege: PlayingRowContainer;
+		weather: WeatherRowContainer;
+		hand: HandContainer;
+		deck: CardData[];
+		deckPosition: { x: number; y: number };
+	};
+
+	enemy: {
+		melee: PlayingRowContainer;
+		ranged: PlayingRowContainer;
+		siege: PlayingRowContainer;
+		hand: HandContainer;
+		deck: CardData[];
+		weather: WeatherRowContainer;
+		deckPosition: { x: number; y: number };
+	};
 }
 
 /**

--- a/aoe-gwent/src/shared/game/GameManager.ts
+++ b/aoe-gwent/src/shared/game/GameManager.ts
@@ -29,6 +29,9 @@ export class GameManager {
 
 	private readonly _scoreCalculator: ScoreCalculator;
 
+	private readonly _playerRows: PlayingRowContainer[];
+	private readonly _enemyRows: PlayingRowContainer[];
+
 	constructor(
 		player: Player,
 		enemy: Player,
@@ -52,6 +55,17 @@ export class GameManager {
 			this._player.melee,
 			this._player.ranged,
 			this._player.siege,
+			this._enemy.melee,
+			this._enemy.ranged,
+			this._enemy.siege,
+		];
+
+		this._playerRows = [
+			this._player.melee,
+			this._player.ranged,
+			this._player.siege,
+		];
+		this._enemyRows = [
 			this._enemy.melee,
 			this._enemy.ranged,
 			this._enemy.siege,
@@ -235,17 +249,43 @@ export class GameManager {
 
 		// Handle one-off effects (weather etc) before calculating score.
 		if (card.cardData.onPlayEffect) {
+			const oppositePlayer =
+				player.id === this._player.id ? this._enemy : this._player;
+
 			const context = {
-				player: action.player,
-				enemy:
-					action.player.id === this._player.id ? this._enemy : this._player,
+				player: {
+					melee: action.player.melee,
+					ranged: action.player.ranged,
+					siege: action.player.siege,
+					weather: action.player.weather,
+					hand: action.player.hand,
+					deck: action.player.deck,
+					deckPosition: action.player.deckPosition,
+				},
+				enemy: {
+					melee: oppositePlayer.melee,
+					ranged: oppositePlayer.ranged,
+					siege: oppositePlayer.siege,
+					weather: oppositePlayer.weather,
+					hand: oppositePlayer.hand,
+					deck: oppositePlayer.deck,
+					deckPosition: oppositePlayer.deckPosition,
+				},
 			};
 
 			await card.cardData.onPlayEffect.fn(context);
 		}
 
 		// Calculate score for all cards, as some cards can affect multiple cards' scores.
-		this._scoreCalculator.calculateScore();
+		const updatedScores = this._scoreCalculator.calculateScore(
+			this._playerRows,
+			this._enemyRows
+		);
+
+		updatedScores.forEach((score, card) => card.setScore(score));
+
+		this._player.updateScore();
+		this._enemy.updateScore();
 
 		// After scores are calculated, we need to update the visuals for all cards on the board to reflect any changes.
 		this._allPlayingRowContainers.map((row) =>

--- a/aoe-gwent/src/shared/game/GameManager.ts
+++ b/aoe-gwent/src/shared/game/GameManager.ts
@@ -271,7 +271,13 @@ export class GameManager {
 		// Calculate score for all cards, as some cards can affect multiple cards' scores.
 		const updatedScores = this._scoreCalculator.calculateScore(context);
 
-		updatedScores.forEach((score, card) => card.setScore(score));
+		updatedScores.player.forEach((score, card) => {
+			card.setScore(score);
+		});
+
+		updatedScores.enemy.forEach((score, card) => {
+			card.setScore(score);
+		});
 
 		this._player.updateScore();
 		this._enemy.updateScore();

--- a/aoe-gwent/src/shared/game/GameManager.ts
+++ b/aoe-gwent/src/shared/game/GameManager.ts
@@ -1,7 +1,13 @@
-import { CardEffect, PlayingRowContainer } from "../../entities/card";
+import {
+	CardData,
+	CardEffect,
+	CardType,
+	PlayingRowContainer,
+} from "../../entities/card";
 import { PlayerDisplayManager } from "../../entities/player";
 import { Player } from "../../entities/player/Player";
 import { CardDatabase, GamePhase } from "../../local-server";
+import { AuraEffects } from "../../local-server/CardEffects";
 import {
 	ActionType,
 	GameData,
@@ -29,9 +35,6 @@ export class GameManager {
 
 	private readonly _scoreCalculator: ScoreCalculator;
 
-	private readonly _playerRows: PlayingRowContainer[];
-	private readonly _enemyRows: PlayingRowContainer[];
-
 	constructor(
 		player: Player,
 		enemy: Player,
@@ -41,7 +44,7 @@ export class GameManager {
 		this._enemy = enemy;
 
 		this._playerDisplayManager = playerDisplayManager;
-		this._scoreCalculator = new ScoreCalculator(player, enemy);
+		this._scoreCalculator = new ScoreCalculator();
 
 		this.gameData = {
 			phase: GamePhase.WAITING_FOR_ROUND_START,
@@ -55,17 +58,6 @@ export class GameManager {
 			this._player.melee,
 			this._player.ranged,
 			this._player.siege,
-			this._enemy.melee,
-			this._enemy.ranged,
-			this._enemy.siege,
-		];
-
-		this._playerRows = [
-			this._player.melee,
-			this._player.ranged,
-			this._player.siege,
-		];
-		this._enemyRows = [
 			this._enemy.melee,
 			this._enemy.ranged,
 			this._enemy.siege,
@@ -247,40 +239,37 @@ export class GameManager {
 			action.player.hand.removeCard(card);
 		}
 
+		const oppositePlayer =
+			player.id === this._player.id ? this._enemy : this._player;
+
+		const context = {
+			player: {
+				melee: action.player.melee,
+				ranged: action.player.ranged,
+				siege: action.player.siege,
+				weather: action.player.weather,
+				hand: action.player.hand,
+				deck: action.player.deck,
+				deckPosition: action.player.deckPosition,
+			},
+			enemy: {
+				melee: oppositePlayer.melee,
+				ranged: oppositePlayer.ranged,
+				siege: oppositePlayer.siege,
+				weather: oppositePlayer.weather,
+				hand: oppositePlayer.hand,
+				deck: oppositePlayer.deck,
+				deckPosition: oppositePlayer.deckPosition,
+			},
+		};
+
 		// Handle one-off effects (weather etc) before calculating score.
 		if (card.cardData.onPlayEffect) {
-			const oppositePlayer =
-				player.id === this._player.id ? this._enemy : this._player;
-
-			const context = {
-				player: {
-					melee: action.player.melee,
-					ranged: action.player.ranged,
-					siege: action.player.siege,
-					weather: action.player.weather,
-					hand: action.player.hand,
-					deck: action.player.deck,
-					deckPosition: action.player.deckPosition,
-				},
-				enemy: {
-					melee: oppositePlayer.melee,
-					ranged: oppositePlayer.ranged,
-					siege: oppositePlayer.siege,
-					weather: oppositePlayer.weather,
-					hand: oppositePlayer.hand,
-					deck: oppositePlayer.deck,
-					deckPosition: oppositePlayer.deckPosition,
-				},
-			};
-
 			await card.cardData.onPlayEffect.fn(context);
 		}
 
 		// Calculate score for all cards, as some cards can affect multiple cards' scores.
-		const updatedScores = this._scoreCalculator.calculateScore(
-			this._playerRows,
-			this._enemyRows
-		);
+		const updatedScores = this._scoreCalculator.calculateScore(context);
 
 		updatedScores.forEach((score, card) => card.setScore(score));
 

--- a/aoe-gwent/src/shared/game/ScoreCalculator.ts
+++ b/aoe-gwent/src/shared/game/ScoreCalculator.ts
@@ -2,10 +2,26 @@ import { Card, PlayingRowContainer } from "../../entities/card";
 import { BattlefieldContext } from "../../local-server/CardEffects";
 
 export class ScoreCalculator {
-	private readonly _rowBuffMap: Map<PlayingRowContainer, number> = new Map();
-	private readonly _cardScoreMap: Map<Card, number> = new Map();
+	private readonly _rowBuffMap: {
+		player: Map<PlayingRowContainer, number>;
+		enemy: Map<PlayingRowContainer, number>;
+	} = {
+		player: new Map(),
+		enemy: new Map(),
+	};
 
-	public calculateScore(context: BattlefieldContext): Map<Card, number> {
+	private readonly _cardScoreMap: {
+		player: Map<Card, number>;
+		enemy: Map<Card, number>;
+	} = {
+		player: new Map(),
+		enemy: new Map(),
+	};
+
+	public calculateScore(context: BattlefieldContext): {
+		player: Map<Card, number>;
+		enemy: Map<Card, number>;
+	} {
 		const playerRows = [
 			context.player.melee,
 			context.player.ranged,
@@ -17,17 +33,33 @@ export class ScoreCalculator {
 			context.enemy.siege,
 		];
 
-		this._rowBuffMap.clear();
-		this._cardScoreMap.clear();
+		this._rowBuffMap.player.clear();
+		this._cardScoreMap.player.clear();
+
+		this._rowBuffMap.enemy.clear();
+		this._cardScoreMap.enemy.clear();
 
 		// Reset scores to base values before applying any effects.
-		for (const row of [...playerRows, ...enemyRows]) {
+		for (const row of enemyRows) {
 			for (const card of row.cards) {
 				if (card.cardData.baseScore === undefined) {
 					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
 				}
 
-				this._cardScoreMap.set(
+				this._cardScoreMap.enemy.set(
+					card,
+					row.weatherEffectApplied ? 1 : card.cardData.baseScore
+				);
+			}
+		}
+
+		for (const row of playerRows) {
+			for (const card of row.cards) {
+				if (card.cardData.baseScore === undefined) {
+					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
+				}
+
+				this._cardScoreMap.player.set(
 					card,
 					row.weatherEffectApplied ? 1 : card.cardData.baseScore
 				);
@@ -35,32 +67,41 @@ export class ScoreCalculator {
 		}
 
 		// Calculate aura effects.
-		const effects = this.calculateAuraEffects(context);
+		const auraEffects = this.calculateAuraEffects(context);
+
+		auraEffects.enemy.forEach((effect) => {
+			const currentValue = this._rowBuffMap.enemy.get(effect.row) ?? 0;
+
+			this._rowBuffMap.enemy.set(effect.row, currentValue + effect.effectValue);
+		});
 
 		// Sum up buffs/debuffs from all aura effects for each row.
-		effects.forEach((effect) => {
-			const currentValue = this._rowBuffMap.get(effect.affectedRow) ?? 0;
+		auraEffects.player.forEach((effect) => {
+			const currentValue = this._rowBuffMap.player.get(effect.row) ?? 0;
 
-			this._rowBuffMap.set(
-				effect.affectedRow,
+			this._rowBuffMap.player.set(
+				effect.row,
 				currentValue + effect.effectValue
 			);
 		});
 
 		// Apply row buffs/debuffs from aura effects to the cards.
-		this._rowBuffMap.forEach((buffAmount, row) => {
+		this._rowBuffMap.player.forEach((buffAmount, row) => {
 			for (const card of row.cards) {
-				const oldScore = this._cardScoreMap.get(card)!;
+				const oldScore = this._cardScoreMap.player.get(card)!;
 				const newScore = oldScore + buffAmount;
 
-				this._cardScoreMap.set(card, Math.max(newScore, 1));
+				this._cardScoreMap.player.set(card, Math.max(newScore, 1));
 			}
 		});
 
 		// Apply card score for player rows.
 		for (const row of playerRows) {
 			for (const card of row.cards) {
-				this._cardScoreMap.set(card, this.calculateCardScore(card, context));
+				this._cardScoreMap.player.set(
+					card,
+					this.calculateCardScore(card, context)
+				);
 			}
 		}
 
@@ -73,20 +114,25 @@ export class ScoreCalculator {
 		// Apply card score for enemy rows.
 		for (const row of enemyRows) {
 			for (const card of row.cards) {
-				this._cardScoreMap.set(
+				this._cardScoreMap.enemy.set(
 					card,
 					this.calculateCardScore(card, swappedContext)
 				);
 			}
 		}
 
-		return new Map(this._cardScoreMap);
+		return {
+			player: this._cardScoreMap.player,
+			enemy: this._cardScoreMap.enemy,
+		};
 	}
 
 	private calculateCardScore(card: Card, context: BattlefieldContext): number {
 		const data = card.cardData;
 
-		let newScore = this._cardScoreMap.get(card)!;
+		let newScore =
+			this._cardScoreMap.player.get(card) ??
+			this._cardScoreMap.enemy.get(card)!;
 
 		if (data.selfEffect) {
 			newScore += data.selfEffect.fn(card, context);
@@ -95,12 +141,16 @@ export class ScoreCalculator {
 		return newScore;
 	}
 
-	private calculateAuraEffects(context: BattlefieldContext): {
-		affectedRow: PlayingRowContainer;
-		effectValue: number;
-	}[] {
-		let effects: {
-			affectedRow: PlayingRowContainer;
+	private calculateAuraEffects(
+		context: BattlefieldContext
+	): AuraEffectModifier {
+		let playerEffects: {
+			row: PlayingRowContainer;
+			effectValue: number;
+		}[] = [];
+
+		let enemyEffects: {
+			row: PlayingRowContainer;
 			effectValue: number;
 		}[] = [];
 
@@ -117,8 +167,8 @@ export class ScoreCalculator {
 
 		for (const row of playerRows) {
 			if (row.strengthBoost) {
-				effects.push({
-					affectedRow: row,
+				playerEffects.push({
+					row: row,
 					effectValue: row.strengthBoost,
 				});
 			}
@@ -127,9 +177,9 @@ export class ScoreCalculator {
 				const effect = card.cardData.auraEffect?.fn(context);
 
 				if (effect) {
-					effects.push({
-						affectedRow: effect.affectedRow,
-						effectValue: effect.effectValue,
+					playerEffects.push({
+						row: effect.row,
+						effectValue: effect.value,
 					});
 				}
 			}
@@ -142,8 +192,8 @@ export class ScoreCalculator {
 
 		for (const row of enemyRows) {
 			if (row.strengthBoost) {
-				effects.push({
-					affectedRow: row,
+				enemyEffects.push({
+					row: row,
 					effectValue: row.strengthBoost,
 				});
 			}
@@ -152,14 +202,29 @@ export class ScoreCalculator {
 				const effect = card.cardData.auraEffect?.fn(swappedContext);
 
 				if (effect) {
-					effects.push({
-						affectedRow: effect.affectedRow,
-						effectValue: effect.effectValue,
+					enemyEffects.push({
+						row: effect.row,
+						effectValue: effect.value,
 					});
 				}
 			}
 		}
 
-		return effects;
+		return {
+			player: playerEffects,
+			enemy: enemyEffects,
+		};
 	}
+}
+
+interface AuraEffectModifier {
+	player: {
+		row: PlayingRowContainer;
+		effectValue: number;
+	}[];
+
+	enemy: {
+		row: PlayingRowContainer;
+		effectValue: number;
+	}[];
 }

--- a/aoe-gwent/src/shared/game/ScoreCalculator.ts
+++ b/aoe-gwent/src/shared/game/ScoreCalculator.ts
@@ -7,6 +7,7 @@ export class ScoreCalculator {
 	private readonly _enemy: Player;
 
 	private readonly _rowBuffMap: Map<PlayingRowContainer, number>;
+	private readonly _cardScoreMap: Map<Card, number> = new Map();
 
 	constructor(player: Player, enemy: Player) {
 		this._player = player;
@@ -14,36 +15,25 @@ export class ScoreCalculator {
 		this._rowBuffMap = new Map();
 	}
 
-	public calculateScore(): void {
-		const playerRows = [
-			this._player.melee,
-			this._player.ranged,
-			this._player.siege,
-		];
-		const enemyRows = [
-			this._enemy.melee,
-			this._enemy.ranged,
-			this._enemy.siege,
-		];
-
+	public calculateScore(
+		playerRows: PlayingRowContainer[],
+		enemyRows: PlayingRowContainer[]
+	): Map<Card, number> {
 		const allRows = [...playerRows, ...enemyRows];
+
+		this._cardScoreMap.clear();
 
 		// Reset scores to base values before applying any effects.
 		for (const row of allRows) {
-			const hasWeatherEffect =
-				row instanceof PlayingRowContainer && row.weatherEffectApplied;
-
 			for (const card of row.cards) {
 				if (card.cardData.baseScore === undefined) {
 					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
 				}
 
-				// We can apply weather effects here.
-				if (hasWeatherEffect) {
-					card.setScore(1);
-				} else {
-					card.setScore(card.cardData.baseScore);
-				}
+				this._cardScoreMap.set(
+					card,
+					row.weatherEffectApplied ? 1 : card.cardData.baseScore
+				);
 			}
 		}
 
@@ -65,27 +55,28 @@ export class ScoreCalculator {
 		// Apply row buffs/debuffs from aura effects to the cards.
 		this._rowBuffMap.forEach((buffAmount, row) => {
 			for (const card of row.cards) {
-				const newScore = card.cardData.score + buffAmount;
-				card.setScore(Math.max(newScore, 1));
+				const oldScore = this._cardScoreMap.get(card)!;
+				const newScore = oldScore + buffAmount;
+
+				this._cardScoreMap.set(card, Math.max(newScore, 1));
 			}
 		});
 
 		// Apply card score for player rows.
 		for (const row of playerRows) {
 			for (const card of row.cards) {
-				card.setScore(this.calculateCardScore(card, true));
+				this._cardScoreMap.set(card, this.calculateCardScore(card, true));
 			}
 		}
 
 		// Apply card score for enemy rows.
 		for (const row of enemyRows) {
 			for (const card of row.cards) {
-				card.setScore(this.calculateCardScore(card, false));
+				this._cardScoreMap.set(card, this.calculateCardScore(card, false));
 			}
 		}
 
-		this._player.updateScore();
-		this._enemy.updateScore();
+		return new Map(this._cardScoreMap);
 	}
 
 	private calculateCardScore(card: Card, isPlayer: boolean): number {
@@ -96,7 +87,7 @@ export class ScoreCalculator {
 			enemy: isPlayer ? this._enemy : this._player,
 		};
 
-		let newScore = data.score;
+		let newScore = this._cardScoreMap.get(card)!;
 
 		if (data.selfEffect) {
 			newScore += data.selfEffect.fn(card, context);

--- a/aoe-gwent/src/shared/game/ScoreCalculator.ts
+++ b/aoe-gwent/src/shared/game/ScoreCalculator.ts
@@ -2,14 +2,6 @@ import { Card, PlayingRowContainer } from "../../entities/card";
 import { BattlefieldContext } from "../../local-server/CardEffects";
 
 export class ScoreCalculator {
-	private readonly _rowBuffMap: {
-		player: Map<PlayingRowContainer, number>;
-		enemy: Map<PlayingRowContainer, number>;
-	} = {
-		player: new Map(),
-		enemy: new Map(),
-	};
-
 	private readonly _cardScoreMap: {
 		player: Map<Card, number>;
 		enemy: Map<Card, number>;
@@ -22,6 +14,11 @@ export class ScoreCalculator {
 		player: Map<Card, number>;
 		enemy: Map<Card, number>;
 	} {
+		const swappedContext: BattlefieldContext = {
+			player: context.enemy,
+			enemy: context.player,
+		};
+
 		const playerRows = [
 			context.player.melee,
 			context.player.ranged,
@@ -33,93 +30,17 @@ export class ScoreCalculator {
 			context.enemy.siege,
 		];
 
-		this._rowBuffMap.player.clear();
 		this._cardScoreMap.player.clear();
-
-		this._rowBuffMap.enemy.clear();
 		this._cardScoreMap.enemy.clear();
 
-		// Reset scores to base values before applying any effects.
-		for (const row of enemyRows) {
-			for (const card of row.cards) {
-				if (card.cardData.baseScore === undefined) {
-					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
-				}
+		this.initBaseScores(playerRows, this._cardScoreMap.player);
+		this.initBaseScores(enemyRows, this._cardScoreMap.enemy);
 
-				this._cardScoreMap.enemy.set(
-					card,
-					row.weatherEffectApplied ? 1 : card.cardData.baseScore
-				);
-			}
-		}
+		this.applyAuraEffects(playerRows, context);
+		this.applyAuraEffects(enemyRows, swappedContext);
 
-		for (const row of playerRows) {
-			for (const card of row.cards) {
-				if (card.cardData.baseScore === undefined) {
-					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
-				}
-
-				this._cardScoreMap.player.set(
-					card,
-					row.weatherEffectApplied ? 1 : card.cardData.baseScore
-				);
-			}
-		}
-
-		// Calculate aura effects.
-		const auraEffects = this.calculateAuraEffects(context);
-
-		auraEffects.enemy.forEach((effect) => {
-			const currentValue = this._rowBuffMap.enemy.get(effect.row) ?? 0;
-
-			this._rowBuffMap.enemy.set(effect.row, currentValue + effect.effectValue);
-		});
-
-		// Sum up buffs/debuffs from all aura effects for each row.
-		auraEffects.player.forEach((effect) => {
-			const currentValue = this._rowBuffMap.player.get(effect.row) ?? 0;
-
-			this._rowBuffMap.player.set(
-				effect.row,
-				currentValue + effect.effectValue
-			);
-		});
-
-		// Apply row buffs/debuffs from aura effects to the cards.
-		this._rowBuffMap.player.forEach((buffAmount, row) => {
-			for (const card of row.cards) {
-				const oldScore = this._cardScoreMap.player.get(card)!;
-				const newScore = oldScore + buffAmount;
-
-				this._cardScoreMap.player.set(card, Math.max(newScore, 1));
-			}
-		});
-
-		// Apply card score for player rows.
-		for (const row of playerRows) {
-			for (const card of row.cards) {
-				this._cardScoreMap.player.set(
-					card,
-					this.calculateCardScore(card, context)
-				);
-			}
-		}
-
-		// Swap context player/enemy to calculate score for enemy cards with correct context.
-		const swappedContext: BattlefieldContext = {
-			player: context.enemy,
-			enemy: context.player,
-		};
-
-		// Apply card score for enemy rows.
-		for (const row of enemyRows) {
-			for (const card of row.cards) {
-				this._cardScoreMap.enemy.set(
-					card,
-					this.calculateCardScore(card, swappedContext)
-				);
-			}
-		}
+		this.applySelfEffects(playerRows, context, this._cardScoreMap.player);
+		this.applySelfEffects(enemyRows, swappedContext, this._cardScoreMap.enemy);
 
 		return {
 			player: this._cardScoreMap.player,
@@ -127,104 +48,71 @@ export class ScoreCalculator {
 		};
 	}
 
-	private calculateCardScore(card: Card, context: BattlefieldContext): number {
-		const data = card.cardData;
+	private initBaseScores(
+		rows: PlayingRowContainer[],
+		scoreMap: Map<Card, number>
+	): void {
+		for (const row of rows) {
+			for (const card of row.cards) {
+				if (card.cardData.baseScore === undefined) {
+					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
+				}
 
-		let newScore =
-			this._cardScoreMap.player.get(card) ??
-			this._cardScoreMap.enemy.get(card)!;
-
-		if (data.selfEffect) {
-			newScore += data.selfEffect.fn(card, context);
+				scoreMap.set(
+					card,
+					row.weatherEffectApplied ? 1 : card.cardData.baseScore
+				);
+			}
 		}
-
-		return newScore;
 	}
 
-	private calculateAuraEffects(
+	private applyAuraEffects(
+		rows: PlayingRowContainer[],
 		context: BattlefieldContext
-	): AuraEffectModifier {
-		let playerEffects: {
-			row: PlayingRowContainer;
-			effectValue: number;
-		}[] = [];
+	): void {
+		const rowBuffMap = new Map<PlayingRowContainer, number>();
 
-		let enemyEffects: {
-			row: PlayingRowContainer;
-			effectValue: number;
-		}[] = [];
-
-		const playerRows = [
-			context.player.melee,
-			context.player.ranged,
-			context.player.siege,
-		];
-		const enemyRows = [
-			context.enemy.melee,
-			context.enemy.ranged,
-			context.enemy.siege,
-		];
-
-		for (const row of playerRows) {
+		for (const row of rows) {
 			if (row.strengthBoost) {
-				playerEffects.push({
-					row: row,
-					effectValue: row.strengthBoost,
-				});
+				rowBuffMap.set(row, (rowBuffMap.get(row) ?? 0) + row.strengthBoost);
 			}
 
 			for (const card of row.cards) {
 				const effect = card.cardData.auraEffect?.fn(context);
 
 				if (effect) {
-					playerEffects.push({
-						row: effect.row,
-						effectValue: effect.value,
-					});
+					rowBuffMap.set(
+						effect.row,
+						(rowBuffMap.get(effect.row) ?? 0) + effect.value
+					);
 				}
 			}
 		}
 
-		const swappedContext: BattlefieldContext = {
-			player: context.enemy,
-			enemy: context.player,
-		};
-
-		for (const row of enemyRows) {
-			if (row.strengthBoost) {
-				enemyEffects.push({
-					row: row,
-					effectValue: row.strengthBoost,
-				});
-			}
-
+		// Apply accumulated buffs/debuffs. Look up the card in both maps since aura
+		// effects can target the opposite side's rows.
+		rowBuffMap.forEach((buffAmount, row) => {
 			for (const card of row.cards) {
-				const effect = card.cardData.auraEffect?.fn(swappedContext);
+				const scoreMap = this._cardScoreMap.player.has(card)
+					? this._cardScoreMap.player
+					: this._cardScoreMap.enemy;
 
-				if (effect) {
-					enemyEffects.push({
-						row: effect.row,
-						effectValue: effect.value,
-					});
-				}
+				const oldScore = scoreMap.get(card)!;
+				scoreMap.set(card, Math.max(oldScore + buffAmount, 1));
+			}
+		});
+	}
+
+	private applySelfEffects(
+		rows: PlayingRowContainer[],
+		context: BattlefieldContext,
+		scoreMap: Map<Card, number>
+	): void {
+		for (const row of rows) {
+			for (const card of row.cards) {
+				const bonus = card.cardData.selfEffect?.fn(card, context) ?? 0;
+				scoreMap.set(card, scoreMap.get(card)! + bonus);
 			}
 		}
-
-		return {
-			player: playerEffects,
-			enemy: enemyEffects,
-		};
 	}
-}
-
-interface AuraEffectModifier {
-	player: {
-		row: PlayingRowContainer;
-		effectValue: number;
-	}[];
-
-	enemy: {
-		row: PlayingRowContainer;
-		effectValue: number;
-	}[];
 }

--- a/aoe-gwent/src/shared/game/ScoreCalculator.ts
+++ b/aoe-gwent/src/shared/game/ScoreCalculator.ts
@@ -1,30 +1,27 @@
 import { Card, PlayingRowContainer } from "../../entities/card";
-import { Player } from "../../entities/player/Player";
 import { BattlefieldContext } from "../../local-server/CardEffects";
 
 export class ScoreCalculator {
-	private readonly _player: Player;
-	private readonly _enemy: Player;
-
-	private readonly _rowBuffMap: Map<PlayingRowContainer, number>;
+	private readonly _rowBuffMap: Map<PlayingRowContainer, number> = new Map();
 	private readonly _cardScoreMap: Map<Card, number> = new Map();
 
-	constructor(player: Player, enemy: Player) {
-		this._player = player;
-		this._enemy = enemy;
-		this._rowBuffMap = new Map();
-	}
+	public calculateScore(context: BattlefieldContext): Map<Card, number> {
+		const playerRows = [
+			context.player.melee,
+			context.player.ranged,
+			context.player.siege,
+		];
+		const enemyRows = [
+			context.enemy.melee,
+			context.enemy.ranged,
+			context.enemy.siege,
+		];
 
-	public calculateScore(
-		playerRows: PlayingRowContainer[],
-		enemyRows: PlayingRowContainer[]
-	): Map<Card, number> {
-		const allRows = [...playerRows, ...enemyRows];
-
+		this._rowBuffMap.clear();
 		this._cardScoreMap.clear();
 
 		// Reset scores to base values before applying any effects.
-		for (const row of allRows) {
+		for (const row of [...playerRows, ...enemyRows]) {
 			for (const card of row.cards) {
 				if (card.cardData.baseScore === undefined) {
 					throw new Error(`Card ${card.cardData.name} is missing baseScore!`);
@@ -38,9 +35,7 @@ export class ScoreCalculator {
 		}
 
 		// Calculate aura effects.
-		const effects = this.calculateAuraEffects(playerRows, enemyRows);
-
-		this._rowBuffMap.clear();
+		const effects = this.calculateAuraEffects(context);
 
 		// Sum up buffs/debuffs from all aura effects for each row.
 		effects.forEach((effect) => {
@@ -65,27 +60,31 @@ export class ScoreCalculator {
 		// Apply card score for player rows.
 		for (const row of playerRows) {
 			for (const card of row.cards) {
-				this._cardScoreMap.set(card, this.calculateCardScore(card, true));
+				this._cardScoreMap.set(card, this.calculateCardScore(card, context));
 			}
 		}
+
+		// Swap context player/enemy to calculate score for enemy cards with correct context.
+		const swappedContext: BattlefieldContext = {
+			player: context.enemy,
+			enemy: context.player,
+		};
 
 		// Apply card score for enemy rows.
 		for (const row of enemyRows) {
 			for (const card of row.cards) {
-				this._cardScoreMap.set(card, this.calculateCardScore(card, false));
+				this._cardScoreMap.set(
+					card,
+					this.calculateCardScore(card, swappedContext)
+				);
 			}
 		}
 
 		return new Map(this._cardScoreMap);
 	}
 
-	private calculateCardScore(card: Card, isPlayer: boolean): number {
+	private calculateCardScore(card: Card, context: BattlefieldContext): number {
 		const data = card.cardData;
-
-		const context: BattlefieldContext = {
-			player: isPlayer ? this._player : this._enemy,
-			enemy: isPlayer ? this._enemy : this._player,
-		};
 
 		let newScore = this._cardScoreMap.get(card)!;
 
@@ -96,27 +95,25 @@ export class ScoreCalculator {
 		return newScore;
 	}
 
-	private calculateAuraEffects(
-		playerRows: PlayingRowContainer[],
-		enemyRows: PlayingRowContainer[]
-	): {
+	private calculateAuraEffects(context: BattlefieldContext): {
 		affectedRow: PlayingRowContainer;
 		effectValue: number;
 	}[] {
-		const contextPlayer: BattlefieldContext = {
-			player: this._player,
-			enemy: this._enemy,
-		};
-
-		const contextEnemy: BattlefieldContext = {
-			player: this._enemy,
-			enemy: this._player,
-		};
-
 		let effects: {
 			affectedRow: PlayingRowContainer;
 			effectValue: number;
 		}[] = [];
+
+		const playerRows = [
+			context.player.melee,
+			context.player.ranged,
+			context.player.siege,
+		];
+		const enemyRows = [
+			context.enemy.melee,
+			context.enemy.ranged,
+			context.enemy.siege,
+		];
 
 		for (const row of playerRows) {
 			if (row.strengthBoost) {
@@ -127,7 +124,7 @@ export class ScoreCalculator {
 			}
 
 			for (const card of row.cards) {
-				const effect = card.cardData.auraEffect?.fn(contextPlayer);
+				const effect = card.cardData.auraEffect?.fn(context);
 
 				if (effect) {
 					effects.push({
@@ -138,6 +135,11 @@ export class ScoreCalculator {
 			}
 		}
 
+		const swappedContext: BattlefieldContext = {
+			player: context.enemy,
+			enemy: context.player,
+		};
+
 		for (const row of enemyRows) {
 			if (row.strengthBoost) {
 				effects.push({
@@ -147,7 +149,7 @@ export class ScoreCalculator {
 			}
 
 			for (const card of row.cards) {
-				const effect = card.cardData.auraEffect?.fn(contextEnemy);
+				const effect = card.cardData.auraEffect?.fn(swappedContext);
 
 				if (effect) {
 					effects.push({


### PR DESCRIPTION
Refactored how game state and score calculation are managed, especially for BOT player decision-making and card effects. It introduces a more detailed battlefield context structure, improves the bot’s card selection logic by simulating future scores, and updates how card effects are processed to use the new context.

**AI and Score Calculation Improvements**
* The bot player (`BotPlayer`) now selects cards based on simulated future scores using a new `ScoreCalculator`, considering the full battlefield context instead of picking randomly. This makes AI decisions more strategic and less predictable.
* The `ScoreCalculator` and effect functions now use a structured `BattlefieldContext` object, which includes all relevant rows, weather, hand, and deck information for both players. This enables more accurate simulation and effect resolution.

**Game State and Effect Handling**
* Card effects (auras, triggers) and the main game manager have been updated to use the new context structure, allowing effects to target specific rows and values more clearly. 
* The game manager now recalculates and updates scores for all cards after any effect is played, ensuring the board state is always accurate.